### PR TITLE
Lead name is not required

### DIFF
--- a/amocrm/apimodels.py
+++ b/amocrm/apimodels.py
@@ -240,8 +240,11 @@ class BaseCompany(_AbstractNamedModel):
         return note
 
 
-class BaseLead(_AbstractNamedModel):
+class BaseLead(_BaseModel):
     contact_model = None
+
+    name = fields._Field('name', required=False)
+    tags = fields._TagsField('tags', 'name')
     status = fields._StatusTypeField(required=True)
     pipeline = fields._TypeField('pipeline_id', choices='pipelines', required=False)
     company = fields.ForeignField(BaseCompany, 'linked_company_id',

--- a/amocrm_tests/test_base.py
+++ b/amocrm_tests/test_base.py
@@ -381,12 +381,6 @@ class TestLead(AmoSettingsMixin, CreateObjMixin, unittest.TestCase):
             lead.save()
         self.assertEqual('status is required', str(context.exception))
 
-        lead.status = 'test1'
-        lead.name = None
-        with self.assertRaises(ValueError) as context:
-            lead.save()
-        self.assertEqual('name is required', str(context.exception))
-
     @amomock.activate
     def test_last_modified_since(self):
         self.create_object()


### PR DESCRIPTION
Lead `name` parameter is not required by amocrm api,  so let's make `apimodel.BaseLead.name` not requred too

![2017-06-29 21 04 01](https://user-images.githubusercontent.com/129239/27703027-c977bcf8-5d0e-11e7-910b-c1d1ddd74d58.png)
