### PR TITLE
Fix lead search when modified_since is datetime instance

### DIFF
--- a/amocrm/base.py
+++ b/amocrm/base.py
@@ -232,7 +232,7 @@ class _BaseAmoManager(six.with_metaclass(ABCMeta)):
         timestamp, container, result = _method.get('timestamp'), _method.get('container'), _method.get('result')
 
         if modified_since:
-            headers = {'if-modified-since': modified_since}
+            headers = {'if-modified-since': six.text_type(modified_since)}
 
         if timestamp:
             _time = timestamp if isinstance(timestamp, str) else 'last_modified'


### PR DESCRIPTION
Fixes an issue with `test_base.TestLead.test_last_modified_since`:

![2017-06-29 21 41 50](https://user-images.githubusercontent.com/129239/27704750-4967780e-5d14-11e7-8716-50b133bcd07b.png)

Not sure about `if-modified-since` rfc date format, but this fix make things better anyway.