### PR TITLE
Возврат нескольких e-mail или телефонов в случае наличия. 

### DIFF
--- a/amocrm/v2/entity/custom_field.py
+++ b/amocrm/v2/entity/custom_field.py
@@ -252,9 +252,15 @@ class ContactPhoneField(TextCustomField):
         super().__init__(*args, **kwargs)
 
     def on_get(self, values):
+        response = []
         for value in values:
             if value["enum_code"] == self._enum_code:
-                return value["value"]
+                response += [value['value']]
+        
+        if len(response) == 1:
+            return response[0]
+
+        return response
 
     def on_set_instance(self, values, value):
         for item in values:


### PR DESCRIPTION
К Issue #45 .

Если у контакта в CRM несколько E-mail или телефонов одного типа(несколько рабочих e-mail`ов), возвращаться будут несколько. 

- Если e-mail / телефон один, будет как и раньше возвращаться строка с этим значением
- Если e-mail`ов / телефонов несколько, они будут возвращаться в виде массива
- Если E-mail`ов / телефонов нет, возвращаться будет None