### PR TITLE
Metadata "main" field renamed to "is_main"

### DIFF
--- a/amocrm/v2/links.py
+++ b/amocrm/v2/links.py
@@ -14,7 +14,7 @@ class LinksInteraction(BaseInteraction):
         data = {"to_entity_id": to_entity.id, "to_entity_type": to_entity._path}
         if main:
             metadata = metadata or {}
-            metadata["main"] = True
+            metadata["is_main"] = True
         data["metadata"] = metadata
         response, status = self.request("post", path, data=[data])
         if status == 400:


### PR DESCRIPTION
Embedded link field denoting main link is erroneously being set as "main", while it's "is_main" per amocrm documentation