### PR TITLE
Возможность указать дату в виде строки

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,11 @@ Example::
         utm = custom_field.UrlCustomField("UTM метка")
         delivery_type = custom_field.SelectCustomField("Способ доставки")
         address = custom_field.TextCustomField("Адрес")
+        date = custom_field.DateCustomField(
+        "Дата платежа")
 
+    my_lead = Lead.objects.get(object_id=33462781)
+    my_lead.date = "10.12.2025" # дату можно указать в виде строки День.Месяц.Год
 
 Однако мапинг всех кастомных полей дело утоминетльное,
 поэтому для генерации файла с готовым мапингом есть команда::

--- a/amocrm/v2/entity/custom_field.py
+++ b/amocrm/v2/entity/custom_field.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timezone
 
 from .. import fields, manager, model
 from ..interaction import GenericInteraction
@@ -244,6 +244,10 @@ class DateCustomField(TextCustomField):
     def on_set(self, value):
         if isinstance(value, datetime):
             value = value.timestamp()
+        if isinstance(value, str):
+            date_obj = datetime.strptime(value, "%d.%m.%Y")
+            date_obj_utc = date_obj.replace(tzinfo=timezone.utc)
+            value = date_obj_utc.strftime("%Y-%m-%dT%H:%M:%S%z")
         return super().on_set(value)
 
 

--- a/amocrm/v2/fields.py
+++ b/amocrm/v2/fields.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from . import exceptions
 from .links import LinksInteraction

--- a/amocrm/v2/fields.py
+++ b/amocrm/v2/fields.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
 from . import exceptions
 from .links import LinksInteraction


### PR DESCRIPTION
Если передать дату в виде строки День.Месяц.Год, то она преобразуется в необходимый формат и загрузится в amoCRM. Теперь не придется самому форматировать дату.